### PR TITLE
Install vscode extensions, attempt #3

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,9 +7,6 @@ COPY --chown=jovyan:jovyan . /home/jovyan/.kernels
 USER root
 
 ENV QUARTO_CLI=https://github.com/quarto-dev/quarto-cli/releases/download/v1.3.433/quarto-1.3.433-linux-amd64.deb
-
-ENV VSCODE_EXT_DIR=/opt/code-server/extensions
-RUN mkdir -p ${VSCODE_EXT_DIR} && chown -R ${NB_USER}: ${VSCODE_EXT_DIR}
     
 RUN wget -O /tmp/quarto.deb ${QUARTO_CLI} && dpkg -i /tmp/quarto.deb && rm -rf /tmp/quarto.deb && apt-get clean
 
@@ -19,8 +16,8 @@ WORKDIR ${HOME}/.kernels
 
 RUN chmod +x install-kernels.sh && cd /home/jovyan/.kernels && ./install-kernels.sh environments
 
-RUN echo "extensions-dir: $VSCODE_EXT_DIR" >> $HOME/.config/code-server/config.yaml && \
-    EXT_LIST="ms-python.python quarto.quarto" && \
+# Install VSCode extensions. These get installed to $CONDA_PREFIX/envs/notebook/share/code-server/extensions/
+RUN EXT_LIST="ms-python.python quarto.quarto" && \
     for EXT in $EXT_LIST; do code-server --install-extension $EXT; done
 
 ENV JUPYTERHUB_HTTP_REFERER=https://openscapes.2i2c.cloud/

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -16,9 +16,7 @@ WORKDIR ${HOME}/.kernels
 
 RUN chmod +x install-kernels.sh && cd /home/jovyan/.kernels && ./install-kernels.sh environments
 
-# Install VSCode extensions. These get installed to $CONDA_PREFIX/envs/notebook/share/code-server/extensions/
-RUN EXT_LIST="ms-python.python quarto.quarto" && \
-    for EXT in $EXT_LIST; do code-server --install-extension $EXT; done
+RUN chmod +x install-vscode-ext.sh && ./install-vscode-ext.sh vscode-extensions.txt
 
 ENV JUPYTERHUB_HTTP_REFERER=https://openscapes.2i2c.cloud/
 

--- a/ci/install-vscode-ext.sh
+++ b/ci/install-vscode-ext.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Install VSCode extensions. 
+# These get installed to $CONDA_PREFIX/envs/notebook/share/code-server/extensions/
+
+ext_file="$1"
+
+echo "Checking for '$ext_file'..."
+
+if test -f "$ext_file"
+then
+    for EXT in $(cat "$ext_file")
+        do code-server --install-extension $EXT
+    done
+fi

--- a/ci/vscode-extensions.txt
+++ b/ci/vscode-extensions.txt
@@ -1,0 +1,3 @@
+ms-python.python
+ms-toolsai.jupyter
+quarto.quarto


### PR DESCRIPTION
Initially we assumed that extensions would be default be installed in `$HOME`, which we wanted to avoid (#30, #31). But it turns out that `code-server` from conda-forge [sets the `--extensions-dir` flag](https://github.com/conda-forge/code-server-feedstock/commit/1a3f7eaf329f522056195364d7cbcb83778767f1#diff-d7075654874cb08007a21aaab3ecd4b3453a9087e7505d034d548b8938b599bc) to `${CONDA_PREFIX}/share/code-server/extensions`, which resolves to `/srv/conda/envs/notebook/share/code-server/extensions` - i.e., outside of `$HOME`. So I don't think we need to configure anything; we should just be able to install the extensions we want in the Dockerfile.

I tested this locally (macOS arm), and it worked:

```
docker build -t openscapes/corn:test . --platform linux/amd64
docker run -p 8888:8888 --platform linux/amd64 openscapes/corn:test jupyter lab --ip 0.0.0.0
```

I had to remove the `postBuild`, as the awsv2 install was failing (on macOS).




