### PR TITLE
Add escapism and pigz

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -88,6 +88,9 @@ dependencies:
   # - jupyter-collaboration
   - code-server >=3.2
   - quarto
+  # For admin (cleaning home dirs)
+  - escapism
+  - pigz
   # we could use more platforms but in the hub only linux-64 is relevant
   - pip 
   - pip:


### PR DESCRIPTION
These are required to run the script to archive old home directories (https://github.com/NASA-Openscapes/2i2cAccessPolicies/blob/main/scripts/archive-home-dirs.py)