### PR TITLE
Add intake-xarray, intake-erddap and python-dotenv to environment

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,6 +1,7 @@
 name: openscapes
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.11
   # distributed python
@@ -40,9 +41,12 @@ dependencies:
   - xarray>=2024.10
   - rioxarray
   - intake
+  - intake-xarray
+  - intake-erddap
   - geopandas
   - rechunker
   - virtualizarr
+  - python-dotenv
   # pangeo-dataviz
   - holoviews
   - geoviews
@@ -70,7 +74,7 @@ dependencies:
   - itslive
   - s3fs
   - erddapy
-  - copernicusmarine
+  - copernicusmarine>=2.1.0
   # Jupyterlab
   - git-lfs
   - dask-labextension


### PR DESCRIPTION
updating to latest copernicusmarine, adding intake-xarray and intake-erddap and python-dotenv.  These are tiny packages so it should be not be a noticable change in the image size.