### PR TITLE
Update environment.yml

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -48,7 +48,7 @@ dependencies:
   - virtualizarr
   - python-dotenv
   # pangeo-dataviz
-  - holoviews
+  - pyviz_comms
   - geoviews
   - hvplot
   - datashader
@@ -73,9 +73,11 @@ dependencies:
   - pystac-client
   - itslive
   - s3fs
+  - fastparquet
   - erddapy
-  - copernicusmarine>=2.1.0
+  - copernicusmarine>=2.1.1
   # Jupyterlab
+  - python-gist
   - git-lfs
   - dask-labextension
   - jupyter-server-proxy>=4.1.1


### PR DESCRIPTION
* fastparquet needed for storing references in parquet.  
* pyviz_comms needed for panel widgets in jupyterlab
* python-gist is not required but makes it easy to post rendered notebooks as gists from terminal command line
* holoviz is a requirement of hvplot, so not needed explicitly
* copernicusmarine bumped to latest version that includes units passed into dataframe