### PR TITLE
Add positron server and bump earthaccess to 0.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# License files
+*.lic

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,9 +2,17 @@ FROM pangeo/base-image:2024.08.18
 # build file for pangeo images
 RUN conda init zsh && conda init bash
 
+USER root
+COPY --chmod=755 install-positron.sh ./
+RUN ./install-positron.sh
+
+# To test locally, put the license file in ci/positron-license.lic and uncomment 
+# the line below to copy it into the image. Do not commit the license file to git.
+# COPY positron-license.lic /opt/positron-server/resources/activation/linux/x86_64/license.lic
+
 USER ${NB_USER}
 
-RUN chmod +x install-vscode-ext.sh && ./install-vscode-ext.sh vscode-extensions.txt
+COPY --chmod=755 install-vscode-ext.sh vscode-extensions.txt ./
+RUN ./install-vscode-ext.sh vscode-extensions.txt
 
 ENV JUPYTERHUB_HTTP_REFERER=https://openscapes.2i2c.cloud/
-

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,7 +12,8 @@ RUN ./install-positron.sh
 
 USER ${NB_USER}
 
-COPY --chmod=755 install-vscode-ext.sh vscode-extensions.txt ./
+COPY --chmod=755 install-vscode-ext.sh ./
+COPY vscode-extensions.txt ./
 RUN ./install-vscode-ext.sh vscode-extensions.txt
 
 ENV JUPYTERHUB_HTTP_REFERER=https://openscapes.2i2c.cloud/

--- a/ci/conda-lock.yml
+++ b/ci/conda-lock.yml
@@ -1865,7 +1865,7 @@ package:
   category: main
   optional: false
 - name: cubed
-  version: 0.26.0
+  version: 0.27.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1883,10 +1883,10 @@ package:
     tenacity: ''
     toolz: ''
     zarr: '!=3.1.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/cubed-0.26.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cubed-0.27.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 04088785c2806e38a682af5fee3870c0
-    sha256: fff4ec93745c0e250e1d59b761ea2fe7a193152c136deb8f742cb12d4f78aa41
+    md5: 16e081f8a043d64154de0492cf3b3c7d
+    sha256: 602245693261d048a436c2ed45295b339bbd7f0d953ccb55f391fda3580eb080
   category: main
   optional: false
 - name: curl
@@ -3108,23 +3108,23 @@ package:
   category: main
   optional: false
 - name: git
-  version: 2.53.0
+  version: 2.54.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.28,<3.0.a0'
-    libcurl: '>=8.18.0,<9.0a0'
-    libexpat: '>=2.7.3,<3.0a0'
+    libcurl: '>=8.20.0,<9.0a0'
+    libexpat: '>=2.8.0,<3.0a0'
     libgcc: '>=14'
     libiconv: '>=1.18,<2.0a0'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     pcre2: '>=10.47,<10.48.0a0'
     perl: 5.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/git-2.53.0-pl5321h6d3cee1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/git-2.54.0-pl5321h6d3cee1_0.conda
   hash:
-    md5: ad8d4260a6dae5f55960b26b237d576b
-    sha256: 33b20cf09ff1c6ca960e6c5f7fad1f08ffd3112a87d79e42ed56f4e1b4cdefe3
+    md5: 25396e7aade67a4d4413431559a47591
+    sha256: 718eb36fe23cac36c7bbeeb21ea0078256c8790b0e949a4ebb322e8e1da6c405
   category: main
   optional: false
 - name: git-lfs
@@ -3152,17 +3152,17 @@ package:
   category: main
   optional: false
 - name: gitpython
-  version: 3.1.49
+  version: 3.1.50
   manager: conda
   platform: linux-64
   dependencies:
     gitdb: '>=4.0.1,<5'
     python: '>=3.10'
     typing_extensions: '>=3.10.0.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.49-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.50-pyhd8ed1ab_0.conda
   hash:
-    md5: f575ca84b698ffa53273b38bbd51009f
-    sha256: a2ad0529ecfe8de0b48c43b2860c18d5f75aa0b062b9e717644bb22390a5caaa
+    md5: 98958318a01373a615f119b1040b3027
+    sha256: 718c9d0cc287ffda978996c4105ddd2863dd7bad7fb5794cdd365bd809ef2fa5
   category: main
   optional: false
 - name: glib-tools
@@ -4517,7 +4517,7 @@ package:
   category: main
   optional: false
 - name: jupyter_server
-  version: 2.18.1
+  version: 2.18.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -4540,10 +4540,10 @@ package:
     tornado: '>=6.2.0'
     traitlets: '>=5.6.0'
     websocket-client: '>=1.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.18.1-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.18.2-pyhcf101f3_0.conda
   hash:
-    md5: 0bfbcb99dbf7d3b833cbca0ea5273fc2
-    sha256: b613da32590f531be5ac5e9656649e7bebf3b948a4243050a4f205dd198efd68
+    md5: 5ee7945accf0f215ddd6055d25d7cd83
+    sha256: 04fb8ea7749f67abaf76df6257bf86688e1389ceed55eb4fb0176fd2e882dbd6
   category: main
   optional: false
 - name: jupyter_server_terminals
@@ -4560,7 +4560,7 @@ package:
   category: main
   optional: false
 - name: jupyterhub-base
-  version: 5.4.5
+  version: 5.4.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -4581,24 +4581,24 @@ package:
     sqlalchemy: '>=1.4.1'
     tornado: '>=5.1'
     traitlets: '>=4.3.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterhub-base-5.4.5-pyhc90fa1f_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterhub-base-5.4.6-pyhc90fa1f_0.conda
   hash:
-    md5: 90e9fa669f5402438a6912fc6441e2a7
-    sha256: 7cd443a55b3bdef7f80ec40666f38ef83c58f3e5d939901cdb58e2ea0168697d
+    md5: cfd634eebc69999b2513eae1cdc84289
+    sha256: c7a223a6525aa420e47e969eff63a750512ee0523d8813351ea3f786f38f52e1
   category: main
   optional: false
 - name: jupyterhub-singleuser
-  version: 5.4.5
+  version: 5.4.6
   manager: conda
   platform: linux-64
   dependencies:
     __unix: ''
-    jupyterhub-base: ==5.4.5
+    jupyterhub-base: ==5.4.6
     jupyterlab: '>=3.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterhub-singleuser-5.4.5-hdbe6b15_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterhub-singleuser-5.4.6-hf97e4f3_0.conda
   hash:
-    md5: 37bdf613445a01139c912d31ee166bef
-    sha256: 9d9bb77565e053238047b68e2334d9534ca4dceea7a8335eb96c7e26fe1a2f01
+    md5: f21926cfd87d1b09d05899a072346344
+    sha256: 6d84f3f8979449398c2d391e845f85653a318c8cbfabc897aaf1bcd9289af175
   category: main
   optional: false
 - name: jupyterlab
@@ -4894,7 +4894,7 @@ package:
   category: main
   optional: false
 - name: lcms2
-  version: '2.19'
+  version: 2.19.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -4902,10 +4902,10 @@ package:
     libgcc: '>=14'
     libjpeg-turbo: '>=3.1.4.1,<4.0a0'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19-h0c24ade_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_0.conda
   hash:
-    md5: f302dbf397ac82eaf9618575d0b5fe33
-    sha256: f1e982b63d505338ff7f9baee80a10360a025b7216deb5ab0fe1494d8ef3bebb
+    md5: f92f984b558e6e6204014b16d212b271
+    sha256: eb89c6c39f2f6a93db55723dbb2f6bba8c8e63e6312bf1abf13e6e9ff45849c8
   category: main
   optional: false
 - name: ld_impl_linux-64
@@ -8602,7 +8602,7 @@ package:
   category: main
   optional: false
 - name: python-build
-  version: 1.4.4
+  version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -8612,10 +8612,10 @@ package:
     pyproject_hooks: ''
     python: ''
     tomli: '>=1.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-build-1.4.4-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-build-1.5.0-pyhc364b38_0.conda
   hash:
-    md5: fc7f0333ad8324e9d1c9d71258e2e200
-    sha256: f8f5131c43b2ba876e9b29299c646435c45217fdac3a5553ddd42ed74bdc8ab0
+    md5: fa587158c0d768127faa1a3b4df01e5d
+    sha256: eb8d5e44fddee9033eb7cfdd5ea584b7594b50e31c7602bef553af0fd4ee9266
   category: main
   optional: false
 - name: python-cmr
@@ -10036,15 +10036,15 @@ package:
   category: main
   optional: false
 - name: traitlets
-  version: 5.14.3
+  version: 5.15.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
   hash:
-    md5: 019a7385be9af33791c989871317e1ed
-    sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
+    md5: 4bada6a6d908a27262af8ebddf4f7492
+    sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
   category: main
   optional: false
 - name: traittypes

--- a/ci/conda-lock.yml
+++ b/ci/conda-lock.yml
@@ -1379,16 +1379,16 @@ package:
   category: main
   optional: false
 - name: cf_xarray
-  version: 0.11.0
+  version: 0.11.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.11'
     xarray: '>=2024.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.11.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/cf_xarray-0.11.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a45b58ebb586e8148b1535acde3669a4
-    sha256: 57ea66ea693ca02a07d6a7550b2ce14bdca363212e7c74d2070936eb3d7f9f10
+    md5: 644e8a0104c4dd9b48d2b126654876fb
+    sha256: 7f8855a09e3c4f136b9af24cb3070bb85dadd9f9afdabb5079d5b47106d2aad7
   category: main
   optional: false
 - name: cffi
@@ -4576,21 +4576,37 @@ package:
   category: main
   optional: false
 - name: jupyterlab-git
-  version: 0.52.0
+  version: 0.53.0
   manager: conda
   platform: linux-64
   dependencies:
-    jupyter_server: '>=2.0,<3.0'
-    nbdime: '>=4.0,<5.0'
+    jupyter_server: '>=2.0.1,<3.0'
+    jupyterlab-git-core: ==0.53.0
+    nbdime: ''
+    python: ''
+    traitlets: '>=5.0,<6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-git-0.53.0-pyh118db6a_0.conda
+  hash:
+    md5: 1eb481aaec804193f0a29e515a4c8d24
+    sha256: 5975ea6f0adc16f731f6598386b05c1def0fcb02e24603c2aff76dc85c650195
+  category: main
+  optional: false
+- name: jupyterlab-git-core
+  version: 0.53.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    anyio: ''
+    nbdime: '>=4.0.1,<4.1'
     nbformat: ''
     packaging: ''
     pexpect: ''
-    python: '>=3.10,<4.0'
+    python: ''
     traitlets: '>=5.0,<6.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-git-0.52.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-git-core-0.53.0-pyhcf101f3_0.conda
   hash:
-    md5: 00f02197d9548d49e4f711444ef30b58
-    sha256: 99b7007f4823f3ac0347dcdcd3c759933040ebac372f1adaf163f81e3a4ab6c1
+    md5: ef7618cdc450e4c5e7b9ff2938c20525
+    sha256: edbad7c29a706e5516776ab9dc4714a15c8df2c83d282a2f6bb5590196643f24
   category: main
   optional: false
 - name: jupyterlab-h5web
@@ -4846,7 +4862,7 @@ package:
   category: main
   optional: false
 - name: leafmap
-  version: 0.61.1
+  version: 0.62.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4862,6 +4878,7 @@ package:
     ipyfilechooser: ''
     ipyleaflet: ''
     ipysheet: ''
+    ipyvue: '>=1.12.0'
     ipyvuetify: ''
     ipywidgets: ''
     jupyterlab: ''
@@ -4883,10 +4900,10 @@ package:
     scooby: ''
     whiteboxgui: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/leafmap-0.61.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/leafmap-0.62.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1491af5ad53fceee56684352ba985157
-    sha256: 99c4654bac9a63df29f0dac5a3a5e1b2d353c3fbfec16eee6822554d45a67c8b
+    md5: 7fb1466373dd34056bc90a8e5b25520c
+    sha256: 1af3bf83ff155914b952a106743b3a45e12e2e98b00f8d9abb0109acb219771c
   category: main
   optional: false
 - name: legacy-cgi
@@ -6673,16 +6690,16 @@ package:
   category: main
   optional: false
 - name: mdit-py-plugins
-  version: 0.6.0
+  version: 0.6.1
   manager: conda
   platform: linux-64
   dependencies:
     markdown-it-py: '>=2.0.0,<5.0.0'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 9a704e945e87078f464726c69071677a
-    sha256: 443e7f8ae88f71b3e7fd9c3d19d3816fb1965e2352d5e01a6bfdf2eccfcf4795
+    md5: ad6821df7a98510117db06e9a833281f
+    sha256: 49db23cbfb1c1d414a14d7540195208b994ebd747beba0f15c903f3a0a2dc446
   category: main
   optional: false
 - name: mdurl
@@ -7208,7 +7225,7 @@ package:
   category: main
   optional: false
 - name: numpy
-  version: 2.4.3
+  version: 2.4.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -7220,10 +7237,10 @@ package:
     libstdcxx: '>=14'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.4-py313hf6604e3_0.conda
   hash:
-    md5: c4a9d2e77eb9fee983a70cf5f047c202
-    sha256: bcf75998ea3ae133df3580fb427d1054b006b093799430f499fd7ce8207d34c7
+    md5: d66c057bf1ecaff2183d1c269268aead
+    sha256: 8d645a0151069e78f19ef085382d91afea7ac1114e8153feb2318672dee4d146
   category: main
   optional: false
 - name: numpy_groupies
@@ -7442,7 +7459,7 @@ package:
   category: main
   optional: false
 - name: orjson
-  version: 3.11.8
+  version: 3.11.9
   manager: conda
   platform: linux-64
   dependencies:
@@ -7450,10 +7467,10 @@ package:
     libgcc: '>=14'
     python: ''
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/orjson-3.11.8-py313h541fbb8_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orjson-3.11.9-py313h541fbb8_0.conda
   hash:
-    md5: e19d5c712d375e98ee31245de9d7c86c
-    sha256: d2b3c537849747953305c8449ce82caa345f0eae7c186e08ac4bccb4dee76b21
+    md5: 19483ddd60c9fa7a865b011ed288c3d9
+    sha256: 21697e46371cf46966638fe022995e2ff4d9d188ddab644ae5f75da7203b3c9f
   category: main
   optional: false
 - name: overrides

--- a/ci/conda-lock.yml
+++ b/ci/conda-lock.yml
@@ -13,7 +13,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: f26e05f1f8b94b6be20815138071a4813ce05b0f0284adfbe930c00be08dde75
+    linux-64: b99b069bdd1026771af1fc8c5da75a9af753ac03922ca69aa65bef90eff03e79
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -75,7 +75,7 @@ package:
   category: main
   optional: false
 - name: aiobotocore
-  version: 3.6.0
+  version: 3.7.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -88,10 +88,10 @@ package:
     python-dateutil: '>=2.1,<3.0.0'
     typing_extensions: '>=4.14.0,<5.0.0'
     wrapt: '>=1.10.10,<3.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.6.0-pyhcf101f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
   hash:
-    md5: 628a9d8f651c9813d9a666616ace4ffb
-    sha256: 40731cc6b50358f3e50ba9be0d144e8f99bc1f2c5e888b145200f829c689b3d1
+    md5: 39f70aca52f1497a72eb9d81baf4d237
+    sha256: 062726d1240acd307ff7e0e4f754c39a0e0c673c8bb4666a32496fec75499a6b
   category: main
   optional: false
 - name: aiohappyeyeballs
@@ -385,40 +385,6 @@ package:
     sha256: 792da8131b1b53ff667bd6fc617ea9087b570305ccb9913deb36b8e12b3b5141
   category: main
   optional: false
-- name: asf_search
-  version: 12.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    asf_search-base: '>=12.1.0,<12.1.1.0a0'
-    python: '>=3.10'
-    remotezip: '>=0.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asf_search-12.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ed556ecb186256ab63fc51c2f8e36006
-    sha256: 1f2309ef6cda29c5bc5dc92308d1a5c20b532cdea83b246ccae22213b905392b
-  category: main
-  optional: false
-- name: asf_search-base
-  version: 12.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ciso8601: ''
-    dateparser: ''
-    importlib-metadata: ''
-    numpy: ''
-    python: '>=3.10'
-    pytz: ''
-    requests: ''
-    shapely: ''
-    tenacity: 8.2.2
-  url: https://conda.anaconda.org/conda-forge/noarch/asf_search-base-12.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b9d6686080a566d802ffba0205435de4
-    sha256: 77316c4fc41387deeb089549067c5edf228e7814b3e3685975eb5eb77beeb4fe
-  category: main
-  optional: false
 - name: asttokens
   version: 3.0.1
   manager: conda
@@ -523,14 +489,14 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-cal: '>=0.9.13,<0.9.14.0a0'
     aws-c-common: '>=0.12.6,<0.12.7.0a0'
-    aws-c-http: '>=0.10.12,<0.10.13.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.1-h2d2dd48_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.1-ha62d5e7_3.conda
   hash:
-    md5: 675ea6d90900350b1dcfa8231a5ea2dd
-    sha256: 292aa18fe6ab5351710e6416fbd683eaef3aa5b1b7396da9350ff08efc660e4f
+    md5: 55eaf7066da1299d217ab32baedc7fa8
+    sha256: ccbf2cc4bea4aab6e071d67ecc2743197759f6df855787e7a5f57f7973f913a2
   category: main
   optional: false
 - name: aws-c-cal
@@ -576,7 +542,7 @@ package:
   category: main
   optional: false
 - name: aws-c-event-stream
-  version: 0.6.0
+  version: 0.7.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -586,14 +552,14 @@ package:
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.6.0-h9b893ba_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.0-h9b893ba_0.conda
   hash:
-    md5: cd4946050ecfcb3c6fd09106ae6a261e
-    sha256: 4a1a060ab40cb4fa39d24418758ca9faa1f51df6918f05143118e79bb11b4350
+    md5: 60076118b1579967748f0c9a2912de7c
+    sha256: 9692edaeaf90f7710b7ec49c7ca42961c59344dafa6fadbaec8c283b0606ca68
   category: main
   optional: false
 - name: aws-c-http
-  version: 0.10.12
+  version: 0.10.13
   manager: conda
   platform: linux-64
   dependencies:
@@ -603,10 +569,10 @@ package:
     aws-c-compression: '>=0.3.2,<0.3.3.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.12-h4bacb7b_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.13-h4bacb7b_0.conda
   hash:
-    md5: 7bc920933e5fb225aba86a788164a8f1
-    sha256: c6f910d400ef9034493988e8cd37bd4712e42d85921122bcda4ba68d4614b131
+    md5: 77f70a9ab785a146dbf66fba00131403
+    sha256: 38cfc8894db6729770ac18f900296c3f7c20f349a5586a8d8e1a62571fce61d5
   category: main
   optional: false
 - name: aws-c-io
@@ -632,17 +598,17 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-common: '>=0.12.6,<0.12.7.0a0'
-    aws-c-http: '>=0.10.12,<0.10.13.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.15.2-he9ea9c5_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.15.2-hc1936db_2.conda
   hash:
-    md5: 8e77514673f5773b40ff8953583938b6
-    sha256: 3fc68793c0ca2c36524ae67abac696ce6b066a8be6b2b980cbdc40ae1310041a
+    md5: 9120bc47b6f837f3cea90928c3e9a8fa
+    sha256: 236ab4138ff4600f95903d2da94125df78577055f6687afa8806db0f6ed2e1a8
   category: main
   optional: false
 - name: aws-c-s3
-  version: 0.11.5
+  version: 0.12.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -650,15 +616,15 @@ package:
     aws-c-auth: '>=0.10.1,<0.10.2.0a0'
     aws-c-cal: '>=0.9.13,<0.9.14.0a0'
     aws-c-common: '>=0.12.6,<0.12.7.0a0'
-    aws-c-http: '>=0.10.12,<0.10.13.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-checksums: '>=0.2.10,<0.2.11.0a0'
     libgcc: '>=14'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.2-he6ee468_1.conda
   hash:
-    md5: 4c5c16bf1133dcfe100f33dd4470998e
-    sha256: c15869656f5fbebe27cc5aa58b23831f75d85502d324fedd7ee7e552c79b495d
+    md5: 50ae8372984b8b98e056ac8f6b70ab29
+    sha256: 4cecb4d595b7cf558087c37b8131cae5204b2c64d75f6b951dc3731d3f872bb8
   category: main
   optional: false
 - name: aws-c-sdkutils
@@ -690,7 +656,7 @@ package:
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.37.4
+  version: 0.38.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -698,18 +664,18 @@ package:
     aws-c-auth: '>=0.10.1,<0.10.2.0a0'
     aws-c-cal: '>=0.9.13,<0.9.14.0a0'
     aws-c-common: '>=0.12.6,<0.12.7.0a0'
-    aws-c-event-stream: '>=0.6.0,<0.6.1.0a0'
-    aws-c-http: '>=0.10.12,<0.10.13.0a0'
+    aws-c-event-stream: '>=0.7.0,<0.7.1.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
     aws-c-mqtt: '>=0.15.2,<0.15.3.0a0'
-    aws-c-s3: '>=0.11.5,<0.11.6.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
     aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.37.4-h4c8aef7_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.38.3-h745e52d_1.conda
   hash:
-    md5: 798a499cf76e530a992365d557ba5827
-    sha256: b82d0bc6d4b716347e1aefb0acc6e4bff04b3f807537ada9b458a7e467beb2a0
+    md5: 6a65b3595a8933808c03ff065dfb7702
+    sha256: 5616649034662ab7846b78b344891f49b895807cabd83918aebb3439aa9ca405
   category: main
   optional: false
 - name: aws-sdk-cpp
@@ -719,16 +685,16 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-common: '>=0.12.6,<0.12.7.0a0'
-    aws-c-event-stream: '>=0.6.0,<0.6.1.0a0'
-    aws-crt-cpp: '>=0.37.4,<0.37.5.0a0'
-    libcurl: '>=8.19.0,<9.0a0'
+    aws-c-event-stream: '>=0.7.0,<0.7.1.0a0'
+    aws-crt-cpp: '>=0.38.3,<0.38.4.0a0'
+    libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hc3785e1_3.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h41c0014_4.conda
   hash:
-    md5: cfffedbfd03d5a6bb74157c14b6f0cdf
-    sha256: 62b7e565852fa061a26281b2890e432853fabefa8ea3dc22d00d39295a030805
+    md5: 169a79ea1127077d8dc36dc963ff55ac
+    sha256: f17585991350e00084614faaa704166a07fdcf58e80c76003e35111093c6e5e9
   category: main
   optional: false
 - name: awscliv2
@@ -878,7 +844,7 @@ package:
   category: main
   optional: false
 - name: backports.zstd
-  version: 1.4.0
+  version: 1.5.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -887,10 +853,10 @@ package:
     python: ''
     python_abi: 3.13.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.4.0-py313h18e8e13_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.5.0-py313h18e8e13_0.conda
   hash:
-    md5: cfe95f3eab50bc3dbd4c3a03f2674bd8
-    sha256: f92ccaef33713bb66d563e8e829dcdb643e1de8c0d29246a999943c68bb8eb6e
+    md5: 0de0c2c1f2677ea074bdda91de5a4c01
+    sha256: 310e114a783b249517d1dd6e74b3f339af30e947bc93446ae4e4e9c86fff7478
   category: main
   optional: false
 - name: bcrypt
@@ -1054,7 +1020,7 @@ package:
   category: main
   optional: false
 - name: bqplot
-  version: 0.13.0
+  version: 0.13.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1065,10 +1031,10 @@ package:
     python: ''
     traitlets: '>=4.3.0,<6.0'
     traittypes: '>=0.0.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/bqplot-0.13.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bqplot-0.13.1-pyhcf101f3_0.conda
   hash:
-    md5: 4b7a4c81835805a879f1308b8dcd110e
-    sha256: 4bde6fa3ae1b725d16d220dbd37994070d2ea1b152f90361e911b282808005e4
+    md5: e5896ff2fd86c75ff54a482e05e80a62
+    sha256: 64adbe086644a6a4555783bb24b82ba6c8c544e2ab7b1a71e8a9f71e527dd001
   category: main
   optional: false
 - name: bqscales
@@ -1270,15 +1236,15 @@ package:
   category: main
   optional: false
 - name: cachelib
-  version: 0.13.0
+  version: 0.14.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/cachelib-0.13.0-pyhd8ed1ab_1.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/cachelib-0.14.0-pyhd8ed1ab_0.conda
   hash:
-    md5: aa353e8215130ccadcc81cf5a45f9579
-    sha256: 42e3aaa2522066e4992b332aef3ce812e62cd73075432a41d2904c74fcd3cee6
+    md5: 7bfdd1627d6a02e17f259d378f41beb5
+    sha256: 1817862b98d4d6011fe969890dd480b498b24e4bd0e40477397bf6ac28ed3b10
   category: main
   optional: false
 - name: cachetools
@@ -1484,21 +1450,6 @@ package:
     sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
   category: main
   optional: false
-- name: ciso8601
-  version: 2.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    python: ''
-    python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/ciso8601-2.3.3-py313h54dd161_1.conda
-  hash:
-    md5: ec4754d3f7cd32b8db467f6749884545
-    sha256: 277fc59168939623b954b9537eaef2d4f955dd120136f7d8931687152c771791
-  category: main
-  optional: false
 - name: click
   version: 8.1.8
   manager: conda
@@ -1587,7 +1538,7 @@ package:
   category: main
   optional: false
 - name: code-server
-  version: 4.117.0
+  version: 4.118.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -1595,10 +1546,10 @@ package:
     libgcc: '>=14'
     libstdcxx: '>=14'
     nodejs: '>=22.22.2,<23.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/code-server-4.117.0-hd6838e5_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/code-server-4.118.0-hd6838e5_0.conda
   hash:
-    md5: 4cfb805ac4d6f67d57a7c23a5373ab97
-    sha256: d3978a93489848d59beed66f3035f551bb404ac470360dd54b67a3955e4fe244
+    md5: 7c372f8a8756ca51fad760337f141f94
+    sha256: 252ed10b76f4abf993d5f0a128c8a5acc4ad2151a7bb4aba0d53149c1d9bd2ad
   category: main
   optional: false
 - name: coiled
@@ -1781,7 +1732,7 @@ package:
   category: main
   optional: false
 - name: copernicusmarine
-  version: 2.4.0
+  version: 2.4.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -1800,10 +1751,10 @@ package:
     tqdm: '>=4.65.0'
     xarray: '>=2024.10.0'
     zarr: '>=2.18.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/copernicusmarine-2.4.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/copernicusmarine-2.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: f3efd2c6f8413562154e820f17d8d22b
-    sha256: f8f2c8489e035d1f5c2ff425ee14f558f52a2e545b403b13e42c93832ac1184e
+    md5: 690847cdb78772816f430fc91490f915
+    sha256: eefbc5d530e8db6aa2e734fb1133e31c8d68bd0e9cc384f94ad0497ef896c543
   category: main
   optional: false
 - name: cpython
@@ -2078,22 +2029,6 @@ package:
     sha256: cfecc3dad48250f530ebd16f52061cb37bc9fdbdfec25098bf2de8424996b0bc
   category: main
   optional: false
-- name: dateparser
-  version: 1.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.10'
-    python-dateutil: '>=2.7.0'
-    pytz: '>=2024.2'
-    regex: '>=2024.9.11'
-    tzlocal: '>=0.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/dateparser-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4d8650857be15983a33032bf18059787
-    sha256: 9ccdd848db68efc03afbf5fc67e92accc912c0b609a4f4ba54b720f0c27c41a2
-  category: main
-  optional: false
 - name: dav1d
   version: 1.2.1
   manager: conda
@@ -2265,18 +2200,6 @@ package:
     sha256: fb8c1b918b3c28ff9cdf21279aad9a50a659dd3bcbdb95d687044fb35b58b2df
   category: main
   optional: false
-- name: docstring_parser
-  version: 0.17.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ce49d3e5a7d20be2ba57a2c670bdd82e
-    sha256: 3069a555097f084d3b7bc8f9efbb42f9907ecbfa24d310c63df9814a8df491af
-  category: main
-  optional: false
 - name: donfig
   version: 0.8.1.post1
   manager: conda
@@ -2308,7 +2231,7 @@ package:
   category: main
   optional: false
 - name: earthaccess
-  version: 0.17.0
+  version: 0.18.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -2323,10 +2246,10 @@ package:
     tenacity: '>=8.0'
     tinynetrc: '>=1.3.1'
     typing_extensions: '>=4.10.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/earthaccess-0.17.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/earthaccess-0.18.0-pyhc364b38_0.conda
   hash:
-    md5: f14d28ada5c985ed8712f8e09b831c06
-    sha256: 0b87a06f6f53b9f5e958473f5d3b7561fb16f629b05fa892bdb567d7cdd2d74f
+    md5: 3ec59d2fd5976f413d75463241b6eab7
+    sha256: 66decdcc60c62e5f8bebcd890fd4676ea5bdab8b5bd03459530f88634a9f6475
   category: main
   optional: false
 - name: ensureconda
@@ -3174,10 +3097,10 @@ package:
     libffi: ''
     libgcc: '>=14'
     libglib: ==2.88.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hcfc306f_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.1-hee1de02_2.conda
   hash:
-    md5: ff216b19c24f3a46e9d17ebcf2f96390
-    sha256: 628015696c106665ae0043f7e9f51298ec9e8f11573734ad67a849c8279cbe33
+    md5: e5a459d2bb98edb88de5a44bfad66b9d
+    sha256: ae41fd5c867bc4e713a8cc1dc06f5b418026fec116cc222abe33e94235c6b241
   category: main
   optional: false
 - name: glog
@@ -3538,22 +3461,22 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     aws-c-auth: '>=0.10.1,<0.10.2.0a0'
     aws-c-common: '>=0.12.6,<0.12.7.0a0'
-    aws-c-http: '>=0.10.12,<0.10.13.0a0'
+    aws-c-http: '>=0.10.13,<0.10.14.0a0'
     aws-c-io: '>=0.26.3,<0.26.4.0a0'
-    aws-c-s3: '>=0.11.5,<0.11.6.0a0'
+    aws-c-s3: '>=0.12.2,<0.12.3.0a0'
     aws-c-sdkutils: '>=0.2.4,<0.2.5.0a0'
     libaec: '>=1.1.5,<2.0a0'
-    libcurl: '>=8.19.0,<9.0a0'
+    libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.5,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
   hash:
-    md5: 1d92558abd05cea0577f83a5eca38733
-    sha256: c6ff674a4a5a237fcf748fed8f64e79df54b42189986e705f35ba64dc6603235
+    md5: 0d0595612fa229dddb5fc565c260a11f
+    sha256: beb8a2fb18924ca7b5b82cfb50f008f882f577daef2c00ed88022abea35fec76
   category: main
   optional: false
 - name: hdf5plugin
@@ -4149,17 +4072,18 @@ package:
   category: main
   optional: false
 - name: itslive
-  version: 0.3.2
+  version: 0.5.1
   manager: conda
   platform: linux-64
   dependencies:
+    boto3: '>=1.28'
     earthaccess: '>=0.5.2'
     matplotlib-base: '>=3.6'
     pandas: '>=1.5.1'
     plotext: '>=0'
     pqdm: '>=0.2.0'
     pyproj: '>=3.3'
-    python: '>=3.9'
+    python: '>=3.10'
     requests: '>=2.28.1'
     rich-click: '>=1.5'
     s3fs: '>=2022.3'
@@ -4167,10 +4091,10 @@ package:
     tabulate: '>=0.9.0'
     xarray: '>=2022.3'
     zarr: '>=2.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/itslive-0.3.2-pyhd8ed1ab_2.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/itslive-0.5.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6e4d0209b8c67ae3cf43d9dadb2b93a2
-    sha256: 16d8ad870d47302eec0bcbe9cd8938d2d6438d6826e37a72f677f353a7be2ec0
+    md5: b0319fb51b6bf812e42cb8d69eb0ef5d
+    sha256: 7a12b88746b66b9deba9d6b0cefd6b1311eda216327d22e2e5d9a89a521f0d0c
   category: main
   optional: false
 - name: jaraco.classes
@@ -4743,7 +4667,7 @@ package:
   category: main
   optional: false
 - name: jupytext
-  version: 1.19.1
+  version: 1.19.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -4754,10 +4678,10 @@ package:
     python: '>=3.10'
     pyyaml: ''
     tomli: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.1-pyhbbac1ac_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.19.2-pyh0398c0e_0.conda
   hash:
-    md5: d8f030e3730713c93a358fdb46f08281
-    sha256: 1027cf4d0eb0c40f36de9e9b78bcdc7edc17b62ff9e7a20ad6bc81422f30713c
+    md5: 866d6b93cd3efa827ac3223c2c3cccbc
+    sha256: 9e6f965d4302285e2cd552311137449fa19ad0b05c2864f41228c1bfa2aacec5
   category: main
   optional: false
 - name: jwcrypto
@@ -5035,10 +4959,10 @@ package:
     lzo: '>=2.10,<3.0a0'
     openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.7-gpl_hc2c16d8_100.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.7-gpl_hc2c16d8_101.conda
   hash:
-    md5: dbeb5c8321cb2408d406a3da16a0ff0d
-    sha256: 2071a3eb03a868effef273eee8bb7baed6ee9fb2fb94421e9958dcf48ab2c599
+    md5: bb1483d91797dae0b466cab86ceb59a7
+    sha256: 78dd3d493d72c7d7c7647912fe383a3545a2695ee308037b64e9d0752ccedbe9
   category: main
   optional: false
 - name: libarrow
@@ -5047,7 +4971,7 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-crt-cpp: '>=0.37.4,<0.37.5.0a0'
+    aws-crt-cpp: '>=0.38.3,<0.38.4.0a0'
     aws-sdk-cpp: '>=1.11.747,<1.11.748.0a0'
     azure-core-cpp: '>=1.16.2,<1.16.3.0a0'
     azure-identity-cpp: '>=1.13.3,<1.13.4.0a0'
@@ -5069,10 +4993,10 @@ package:
     orc: '>=2.3.0,<2.3.1.0a0'
     snappy: '>=1.2.2,<1.3.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-24.0.0-ha7f89c6_0_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-24.0.0-h0935d00_1_cpu.conda
   hash:
-    md5: 8aeb79715524b48267068fb0fd185956
-    sha256: 0117df14b22d795ee56d5fc08ceabc14e12fa9c93d64979e3616260225ed30ca
+    md5: aed984d45692d6211ebf013b62c9fa02
+    sha256: d2325979993c71580e571eaa470e0ca33b86acb23c653909fecaef688a1c44b4
   category: main
   optional: false
 - name: libarrow-acero
@@ -5085,10 +5009,10 @@ package:
     libarrow-compute: 24.0.0
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_0_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_1_cpu.conda
   hash:
-    md5: 178d7e3f5c392e606ccd0aaff4331019
-    sha256: a46a6264bea99b9980dfd469922a43a6ad8ed579b5d58c5236811b2893082ba7
+    md5: fa76d2ed4b435617a0fe5b8e7b9ae9c1
+    sha256: d5e2ca1557393490eb0b921d0dabe6203c685da97c0cf8c5b15c21c2d69b517a
   category: main
   optional: false
 - name: libarrow-compute
@@ -5103,10 +5027,10 @@ package:
     libstdcxx: '>=14'
     libutf8proc: '>=2.11.3,<2.12.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_0_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_1_cpu.conda
   hash:
-    md5: 73e0aeaa603ff40128e75435a3c5ac77
-    sha256: 24886c26b36267d706be56c06bd89b1692e3da0e3099bdc6bd5cecd042cca606
+    md5: 0aac1926c3b2f8c35570af6be677f8ad
+    sha256: e4ca855698a8005508114a8c197ae7fe48ea37430064253a2055dbb0122f8a39
   category: main
   optional: false
 - name: libarrow-dataset
@@ -5121,10 +5045,10 @@ package:
     libgcc: '>=14'
     libparquet: 24.0.0
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_0_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_1_cpu.conda
   hash:
-    md5: dc226b80ae51753ce2bd8193dcc42a88
-    sha256: 37293ee47f819072805e7e23d3ed15e7f1baccfacb2080ed360a96e208d930b2
+    md5: 021214e64486a6ba4df95d64b703f1fb
+    sha256: 38ce55721b4d2cc776d0e34078ccba63dfd5c141f1f49bb41cd6ae4da10c21e4
   category: main
   optional: false
 - name: libarrow-substrait
@@ -5140,10 +5064,10 @@ package:
     libgcc: '>=14'
     libprotobuf: '>=6.33.5,<6.33.6.0a0'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_0_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_1_cpu.conda
   hash:
-    md5: cb5a9557a2ffa1b18b4e05621354c6bd
-    sha256: ea628348819cbccf73b0440071c437e33db05e01fd9c7d4f6a0268c0217c12fc
+    md5: e3e42803a838c2177759e6aef1363512
+    sha256: 9479a863e61e5cc3e3ef395267f23dc1475199f53a96c0d04a168f4b0c97db2a
   category: main
   optional: false
 - name: libavif16
@@ -5168,11 +5092,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.32,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h4a7cf45_openblas.conda
+    libopenblas: '>=0.3.33,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-7_h4a7cf45_openblas.conda
   hash:
-    md5: 6d6d225559bfa6e2f3c90ee9c03d4e2e
-    sha256: 7bfe936dbb5db04820cf300a9cc1f5ee8d5302fc896c2d66e30f1ee2f20fbfd6
+    md5: 955b44e8b00b7f7ef4ce0130cef12394
+    sha256: 081c850f99bc355821fac9c6e3727d40b3f8ce3beb50a5437cf03726b611ff39
   category: main
   optional: false
 - name: libbrotlicommon
@@ -5235,10 +5159,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-7_h0358290_openblas.conda
   hash:
-    md5: 36ae340a916635b97ac8a0655ace2a35
-    sha256: 57edafa7796f6fa3ebbd5367692dd4c7f552be42109c2dd1a7c89b55089bf374
+    md5: 0675639dc24cb0032f199e7ff68e4633
+    sha256: 956ae0bb1ec8b0c3663d75b151aceb0521b54e513bf97f621a035f9c87037970
   category: main
   optional: false
 - name: libcbor
@@ -5474,10 +5398,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
   hash:
-    md5: 0aa00f03f9e39fb9876085dee11a85d4
-    sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
+    md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+    sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
   category: main
   optional: false
 - name: libgcc-ng
@@ -5486,10 +5410,10 @@ package:
   platform: linux-64
   dependencies:
     libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
   hash:
-    md5: d5e96b1ed75ca01906b3d2469b4ce493
-    sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
+    md5: 331ee9b72b9dff570d56b1302c5ab37d
+    sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
   category: main
   optional: false
 - name: libgd
@@ -5558,39 +5482,6 @@ package:
     sha256: 298497351f4a7dc94938a1ad8dc3df545a07efdc5f1b91b9256d04e65959a430
   category: main
   optional: false
-- name: libgdal-hdf4
-  version: 3.12.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    libaec: '>=1.1.5,<2.0a0'
-    libgcc: '>=14'
-    libgdal-core: 3.12.3
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.3-hf70aa56_3.conda
-  hash:
-    md5: 5429ab06028218ac67e11695b4b66a96
-    sha256: dc0ffd3fdce474ff3f975dadda48f971bff6604b83391b3cd9b4c3e43408335e
-  category: main
-  optional: false
-- name: libgdal-hdf5
-  version: 3.12.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    hdf5: '>=2.1.0,<3.0a0'
-    libgcc: '>=14'
-    libgdal-core: 3.12.3
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.3-ha9bf034_3.conda
-  hash:
-    md5: f019b2a48a736bf0357b0e24176ab941
-    sha256: 168bf24d820814a1bea1f1e308eb1116bea11e218ad5e018014f68e04852bc16
-  category: main
-  optional: false
 - name: libgdal-jp2openjpeg
   version: 3.12.3
   manager: conda
@@ -5607,36 +5498,16 @@ package:
     sha256: d02e8a3a9dd288acb5006150783ab93a4d1a6dec4c1b0eb60699456f52efda77
   category: main
   optional: false
-- name: libgdal-netcdf
-  version: 3.12.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    hdf4: '>=4.2.15,<4.2.16.0a0'
-    hdf5: '>=2.1.0,<3.0a0'
-    libgcc: '>=14'
-    libgdal-core: 3.12.3
-    libgdal-hdf4: 3.12.3.*
-    libgdal-hdf5: 3.12.3.*
-    libnetcdf: '>=4.10.0,<4.10.1.0a0'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.3-ha903712_3.conda
-  hash:
-    md5: 558c0691cd8ff91fd0baeb4943476a8a
-    sha256: 0be40bdfcd0964e1c092d6524167524925039821be3d3be5cd7b60c3c37f0799
-  category: main
-  optional: false
 - name: libgfortran
   version: 15.2.0
   manager: conda
   platform: linux-64
   dependencies:
     libgfortran5: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
   hash:
-    md5: 9063115da5bc35fdc3e1002e69b9ef6e
-    sha256: d2c9fad338fd85e4487424865da8e74006ab2e2475bd788f624d7a39b2a72aee
+    md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
+    sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
   category: main
   optional: false
 - name: libgfortran5
@@ -5646,10 +5517,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=15.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
   hash:
-    md5: 646855f357199a12f02a87382d429b75
-    sha256: 539b57cf50ec85509a94ba9949b7e30717839e4d694bc94f30d41c9d34de2d12
+    md5: 85072b0ad177c966294f129b7c04a2d5
+    sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
   category: main
   optional: false
 - name: libgl
@@ -5691,10 +5562,10 @@ package:
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
   hash:
-    md5: 6016ea5ee9e986bc683879408cc87529
-    sha256: a0899efbae2a6a9102c796c0b11ac371a3190da5afa28512eeb2879c65d1419c
+    md5: 17d484ab9c8179c6a6e5b7dbb5065afc
+    sha256: 33eb5d5310a5c2c0a4707a0afa644801c2e08c8f70c45e1f62f354116dfe0970
   category: main
   optional: false
 - name: libglvnd
@@ -5744,10 +5615,10 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
   hash:
-    md5: 239c5e9546c38a1e884d69effcf4c882
-    sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
+    md5: faac990cb7aedc7f3a2224f2c9b0c26c
+    sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
   category: main
   optional: false
 - name: libgoogle-cloud
@@ -5891,10 +5762,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-7_h47877c9_openblas.conda
   hash:
-    md5: 881d801569b201c2e753f03c84b85e15
-    sha256: 371f517eb7010b21c6cc882c7606daccebb943307cb9a3bf2c70456a5c024f7d
+    md5: 6569b4f273740e25dc0dc7e3232c2a6c
+    sha256: 96962084921f197c9ad13fb7f8b324f2351d50ff3d8d962148751ad532f54a01
   category: main
   optional: false
 - name: liblzma
@@ -5981,7 +5852,7 @@ package:
   category: main
   optional: false
 - name: libopenblas
-  version: 0.3.32
+  version: 0.3.33
   manager: conda
   platform: linux-64
   dependencies:
@@ -5989,10 +5860,10 @@ package:
     libgcc: '>=14'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
   hash:
-    md5: 89d61bc91d3f39fda0ca10fcd3c68594
-    sha256: 6dc30b28f32737a1c52dada10c8f3a41bc9e021854215efca04a7f00487d09d9
+    md5: 2d3278b721e40468295ca755c3b84070
+    sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
   category: main
   optional: false
 - name: libopentelemetry-cpp
@@ -6036,10 +5907,10 @@ package:
     libstdcxx: '>=14'
     libthrift: '>=0.22.0,<0.22.1.0a0'
     openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-24.0.0-h7376487_0_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-24.0.0-h7376487_1_cpu.conda
   hash:
-    md5: c828cca50cd3a7c53d12ce8f0872c6ec
-    sha256: 374a9c6222df047ab6d43c6efe96d380b7750b53ec9b84fc9ad8bf1c22df4522
+    md5: 5e60f3c311d00d456f089177bb75ebaf
+    sha256: 65d6ba055d872911d30f55b8bf2880ff05f57f2a9cc59447be1dccce07f68109
   category: main
   optional: false
 - name: libpciaccess
@@ -6210,10 +6081,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
   hash:
-    md5: 1b08cd684f34175e4514474793d44bcb
-    sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
+    md5: 5794b3bdc38177caf969dabd3af08549
+    sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
   category: main
   optional: false
 - name: libstdcxx-ng
@@ -6222,10 +6093,10 @@ package:
   platform: linux-64
   dependencies:
     libstdcxx: 15.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
   hash:
-    md5: 6235adb93d064ecdf3d44faee6f468de
-    sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
+    md5: e5ce228e579726c07255dbf90dc62101
+    sha256: 0672b6b6e1791c92e8eccad58081a99d614fcf82bca5841f9dfa3c3e658f83b9
   category: main
   optional: false
 - name: libthrift
@@ -6731,16 +6602,16 @@ package:
   category: main
   optional: false
 - name: markdown-it-py
-  version: 4.0.0
+  version: 4.2.0
   manager: conda
   platform: linux-64
   dependencies:
     mdurl: '>=0.1,<1'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 5b5203189eb668f042ac2b0826244964
-    sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
+    md5: 6d03368f2b2b0a5fb6839df53b2eb5e0
+    sha256: 0c4c35376fe920714390d46e4b8d31c876d65f18e1655899e0763ec25f2a902f
   category: main
   optional: false
 - name: markupsafe
@@ -6789,29 +6660,29 @@ package:
   category: main
   optional: false
 - name: matplotlib-inline
-  version: 0.2.1
+  version: 0.2.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
     traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 00e120ce3e40bad7bfc78861ce3c4a25
-    sha256: 9d690334de0cd1d22c51bc28420663f4277cfa60d34fa5cad1ce284a13f1d603
+    md5: 9acc1c385be401d533ff70ef5b50dae6
+    sha256: 35b43d7343f74452307fd018a1cca92b8f68961ff8e2ab6a81ce0a703c9a3764
   category: main
   optional: false
 - name: mdit-py-plugins
-  version: 0.5.0
+  version: 0.6.0
   manager: conda
   platform: linux-64
   dependencies:
     markdown-it-py: '>=2.0.0,<5.0.0'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.5.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1997a083ef0b4c9331f9191564be275e
-    sha256: 123cc004e2946879708cdb6a9eff24acbbb054990d6131bb94bca7a374ebebfc
+    md5: 9a704e945e87078f464726c69071677a
+    sha256: 443e7f8ae88f71b3e7fd9c3d19d3816fb1965e2352d5e01a6bfdf2eccfcf4795
   category: main
   optional: false
 - name: mdurl
@@ -6983,15 +6854,15 @@ package:
   category: main
   optional: false
 - name: narwhals
-  version: 2.20.0
+  version: 2.21.0
   manager: conda
   platform: linux-64
   dependencies:
     python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.21.0-pyhcf101f3_0.conda
   hash:
-    md5: 6cac1a50359219d786453c6fef819f98
-    sha256: 676cbfbf709ce984a14e3af5aef70f1ec94a29ea3fdec477115ae302b34a1a2d
+    md5: d2ec42db1d2fcd69003c8b069fb4301c
+    sha256: 41e391ec624b67586e1d2d5ae1651f88b283fa0b68cce998c281e69e2e5d7573
   category: main
   optional: false
 - name: nbclient
@@ -7292,10 +7163,10 @@ package:
     numpy: '>=1.23,<3'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.65.1-py313h5dce7c4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.65.1-py313h5dce7c4_1.conda
   hash:
-    md5: 9bf6fdae64fce80e917e23d7cfec771a
-    sha256: 3e721a1b7555f09dc30d466a867c677a3d86e2e4b4837b811659a91495c892c4
+    md5: b19dde1f8eee0382e51edcd0b62bfa8c
+    sha256: 0b3a763972fea13df4025f9021b2452e86e6a8cd55f7594ea35b8cbafa834658
   category: main
   optional: false
 - name: numcodecs
@@ -7330,10 +7201,10 @@ package:
     numpy: '>=1.23.0'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.14.1-py313h24ae7f9_101.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numexpr-2.14.1-py313h24ae7f9_102.conda
   hash:
-    md5: b7e46fb2704458afc67fb95773528967
-    sha256: 26917aa008b9753ec0e4658521ee6ef144414f49db65e2ce83fbf316914f318b
+    md5: ea50335f1bf97fd53b21129f95835051
+    sha256: 7ef0f8ef6e08e4a62cb27b7147c8b1c5a12097b3ec73c2ed4ccede11bc58630d
   category: main
   optional: false
 - name: numpy
@@ -7483,7 +7354,7 @@ package:
   category: main
   optional: false
 - name: openjph
-  version: 0.27.0
+  version: 0.27.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -7491,10 +7362,10 @@ package:
     libgcc: '>=14'
     libstdcxx: '>=14'
     libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.27.0-h8d634f6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.27.2-h8d634f6_0.conda
   hash:
-    md5: 8397bb8cf4b370f5df7d7ee3d80ea977
-    sha256: 7feff0a0cf14ee008ae03fc83fa556d5d0acfac870a6ce4371d6a75e5edc8d0a
+    md5: ac7564cac998d4df2f030de2e532291d
+    sha256: f88a521cd891475ac2bbfd8fb657774f2d1d0777c9316bcd55f55c397d1301c9
   category: main
   optional: false
 - name: openssh
@@ -7531,37 +7402,22 @@ package:
   category: main
   optional: false
 - name: opera-utils
-  version: 0.25.6
+  version: 0.19.0
   manager: conda
   platform: linux-64
   dependencies:
-    affine: ''
-    aiohttp: ''
-    asf_search: '>=6.7'
-    botocore: ''
-    dask: ''
-    fsspec: ''
-    gdal: '>=3.8'
-    h5netcdf: ''
+    click: '>=7.0'
     h5py: '>=1.10'
-    libgdal-netcdf: ''
     numpy: '>=1.20'
-    pandas: ''
     pooch: '>=1.7'
     pyproj: '>=3.3'
-    python: '>=3.11'
-    rasterio: '>=1.3'
-    s3fs: ''
+    python: '>=3.9'
     shapely: '>=1.8'
-    tqdm: ''
     typing_extensions: '>=4.9'
-    tyro: '>=0.9'
-    xarray: '>=2025.01'
-    zarr: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/opera-utils-0.25.6-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/opera-utils-0.19.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 184b48a8ff281cfb71d69d07f94d802e
-    sha256: adbad1d2ebbc379628382a21c8b70ae81f2e6892e7bfc7bd1a9e5743e98fa738
+    md5: 8625745d1b02bb0f4777b91046042e6d
+    sha256: cc479dc68c7dd965ec8a7b94ef83ce5036eafb4dc15f9041e15adc6ce5169c81
   category: main
   optional: false
 - name: orc
@@ -7638,7 +7494,7 @@ package:
   category: main
   optional: false
 - name: pandas
-  version: 3.0.2
+  version: 3.0.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -7649,10 +7505,10 @@ package:
     python: ''
     python-dateutil: '>=2.8.2'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.2-py313hbfd7664_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py313hbfd7664_0.conda
   hash:
-    md5: 6a036e42f4e47720804f35d1897336a1
-    sha256: 6aa7b7b234805c673fd63ef60432362e6cc130a3ae09b5ed2b40d74a2bd6c7bb
+    md5: 70d4dd67877354f6912af31177cb1117
+    sha256: a02d58327a57eb2f149c040b31c758fc6acea7c6aa5cb09b40b146eb6ed637d9
   category: main
   optional: false
 - name: pandoc
@@ -7741,7 +7597,7 @@ package:
   category: main
   optional: false
 - name: paramiko
-  version: 4.0.0
+  version: 5.0.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -7749,11 +7605,11 @@ package:
     cryptography: '>=3.3'
     invoke: '>=2.0'
     pynacl: '>=1.5'
-    python: '>=3.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-4.0.0-pyhd8ed1ab_0.conda
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/paramiko-5.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 1a884d2b1ea21abfb73911dcdb8342e4
-    sha256: ce76d5a1fc6c7ef636cbdbf14ce2d601a1bfa0dd8d286507c1fd02546fccb94b
+    md5: e7fa4da3b74ededb2fa7ab4171f63d21
+    sha256: 1b64a1b91b57c2a4c42a9e73b9a544e22fcdac55a953d2c09644b184edde7c3f
   category: main
   optional: false
 - name: parso
@@ -8290,23 +8146,23 @@ package:
   category: main
   optional: false
 - name: pydantic
-  version: 2.13.3
+  version: 2.13.4
   manager: conda
   platform: linux-64
   dependencies:
     annotated-types: '>=0.6.0'
-    pydantic-core: 2.46.3
+    pydantic-core: 2.46.4
     python: ''
     typing-inspection: '>=0.4.2'
     typing_extensions: '>=4.14.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.3-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
   hash:
-    md5: f690e6f204efd2e5c06b57518a383d98
-    sha256: 12909d5c2bfb31492667dd4132ac900dd47f8162bd8b1dd9e5973ce8ea28ca1a
+    md5: 729843edafc0899b3348bd3f19525b9d
+    sha256: 69700e31165df070e9716315e042196aa92525dae5deb5107785847ab9f4189f
   category: main
   optional: false
 - name: pydantic-core
-  version: 2.46.3
+  version: 2.46.4
   manager: conda
   platform: linux-64
   dependencies:
@@ -8315,10 +8171,10 @@ package:
     python: ''
     python_abi: 3.13.*
     typing-extensions: '>=4.6.0,!=4.7.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.3-py313h843e2db_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py313h843e2db_0.conda
   hash:
-    md5: 81752daa2838eec5df529e5c60044dc5
-    sha256: 885d7809b6f9e011f8cd7294ab030535a65637a229fb5e49453f7be4f05c3083
+    md5: ef0f9efec6ec28b17e22f787c7672c67
+    sha256: d6705962afa2655cc22edcd075ce1f7e67c4407c005137d6d63c0dc5eaa76f47
   category: main
   optional: false
 - name: pydap
@@ -9009,7 +8865,7 @@ package:
   category: main
   optional: false
 - name: regex
-  version: 2026.4.4
+  version: 2026.5.9
   manager: conda
   platform: linux-64
   dependencies:
@@ -9017,23 +8873,10 @@ package:
     libgcc: '>=14'
     python: '>=3.13,<3.14.0a0'
     python_abi: 3.13.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.4.4-py313h07c4f96_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.5.9-py313h07c4f96_0.conda
   hash:
-    md5: df0b7da79c379a22e78ce6569c786369
-    sha256: 26a0ac1a217e008e0cdfd09888f669d916305a0c00a2def6ed547d0c4346ade4
-  category: main
-  optional: false
-- name: remotezip
-  version: 0.12.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.9'
-    requests: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/remotezip-0.12.3-pyhd8ed1ab_1.conda
-  hash:
-    md5: ae636b9c45eaf85205950fc94401fd8b
-    sha256: ef52d7c1870a13740df224f370ff6457f1135f319ab7a0a2b13ce5fd34b0eeab
+    md5: a7611bf1f60104fbe8b88c2949d9af3f
+    sha256: df1dd5cef9b31addec6689f24557da950a733c8104e4133138ba5e20ea9ac8b3
   category: main
   optional: false
 - name: requests
@@ -9053,7 +8896,7 @@ package:
   category: main
   optional: false
 - name: requests-cache
-  version: 1.3.1
+  version: 1.3.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -9067,10 +8910,10 @@ package:
     ujson: '>=5.4'
     url-normalize: '>=1.4'
     urllib3: '>=1.25.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-cache-1.3.2-pyhd8ed1ab_0.conda
   hash:
-    md5: cb9d061ef6ddabbe09b2dddffb96c476
-    sha256: 046b72d49c5856c3e7711ba5b790c55905b78e25baf4531c1f52c655da84e505
+    md5: 2b25a90124b8bbc7d01474dafecc815e
+    sha256: 38d756255053c286a857545ea1343e3b370f04972a170073ee67b52b627e1517
   category: main
   optional: false
 - name: requests-toolbelt
@@ -9541,18 +9384,6 @@ package:
     sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
   category: main
   optional: false
-- name: shtab
-  version: 1.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3b92b45edc5da4cbd603dd7a059f402a
-    sha256: 02567ec721dd5ff6e8942c1cf1db9bb12df64409ff48fc3571b212c122ef9006
-  category: main
-  optional: false
 - name: simpervisor
   version: 1.0.0
   manager: conda
@@ -9605,7 +9436,7 @@ package:
   category: main
   optional: false
 - name: sliderule
-  version: 5.3.2
+  version: 5.4.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -9616,10 +9447,10 @@ package:
     python: '>=3.10'
     requests: ''
     shapely: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/sliderule-5.3.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/sliderule-5.4.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 60332767b633b8260a94ec68444b83eb
-    sha256: 93ffea62b26c96f39665ac116b56945cce3c80ede6ed832d323eb2ba2cc99b32
+    md5: 204970424506f3aae6d42743e7fabc27
+    sha256: c5ea60fd98c363396152e6973db06741502cf60c6dffc86dc31bc6bd3213d9a3
   category: main
   optional: false
 - name: smmap
@@ -9868,15 +9699,15 @@ package:
   category: main
   optional: false
 - name: tenacity
-  version: 8.2.2
+  version: 9.1.4
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-8.2.2-pyhd8ed1ab_0.conda
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
   hash:
-    md5: 7b39e842b52966a99e229739cd4dc36e
-    sha256: 23abf9c14b59fa9787a56a6abb519ac14a9b19091d6c5d7446886d955493b95e
+    md5: 043f0599dc8aa023369deacdb5ac24eb
+    sha256: 32e75900d6a094ffe4290a8c9f1fa15744d9da8ff617aba4acaa0f057a065c34
   category: main
   optional: false
 - name: terminado
@@ -9984,15 +9815,15 @@ package:
   category: main
   optional: false
 - name: tomlkit
-  version: 0.14.0
+  version: 0.15.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.15.0-pyha770c72_0.conda
   hash:
-    md5: 385dca77a8b0ec6fa9b92cb62d09b43b
-    sha256: b35082091c8efd084e51bc3a4a2d3b07897eff232aaf58cbc0f959b6291a6a93
+    md5: 42ef10a8f7f5d55a2e267c0d5daa6387
+    sha256: 1cd52f9ccb4854c4d731438afe0e833b6b71edaf5ede661152aa98efb3a7cc70
   category: main
   optional: false
 - name: toolz
@@ -10061,30 +9892,15 @@ package:
   category: main
   optional: false
 - name: trove-classifiers
-  version: 2026.4.28.13
+  version: 2026.5.7.17
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.4.28.13-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.5.7.17-pyhd8ed1ab_0.conda
   hash:
-    md5: 3eea6839d5b20aa81c00a3c3e0fc3504
-    sha256: d8f62a784845800fc6b196b7b996757844238ab30438bc8db2ebc32b1132bb0d
-  category: main
-  optional: false
-- name: typeguard
-  version: 4.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib-metadata: '>=3.6'
-    python: ''
-    typing-extensions: '>=4.10.0'
-    typing_extensions: '>=4.14.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.1-pyhcf101f3_1.conda
-  hash:
-    md5: 7b80dd11eca2644aac219fd17e9cb035
-    sha256: 3191f16e1effbb16c30b42bc74c37392d3ddc08a8abbd129932755e4698e6e07
+    md5: 58ad6f35e45eca7db0fd5da95aafc693
+    sha256: b06931edfab2f6bde64fae1e7323216b74389b5a27242bf2b54b401246efb04d
   category: main
   optional: false
 - name: typing-extensions
@@ -10150,26 +9966,6 @@ package:
     sha256: 2051dee6a67d43a0ff0fd2ff9dacd8ef533e89d0b30feedf87613fc84b00c247
   category: main
   optional: false
-- name: tyro
-  version: 1.0.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    colorama: '>=0.4.0'
-    docstring_parser: '>=0.15'
-    eval_type_backport: '>=0.1.3'
-    python: '>=3.10'
-    pyyaml: '>=6.0'
-    rich: '>=11.1.0'
-    shtab: '>=1.5.6'
-    typeguard: '>=4.0.0'
-    typing-extensions: '>=4.13.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/tyro-1.0.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2ee651810ee627d8fc9aeee98490ab60
-    sha256: 43d8a2228bc61aa7285f547fb7fd734aa9dc420edcf6e88828b2f67419e767b8
-  category: main
-  optional: false
 - name: tzdata
   version: 2025c
   manager: conda
@@ -10179,19 +9975,6 @@ package:
   hash:
     md5: ad659d0a2b3e47e38d829aa8cad2d610
     sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
-  category: main
-  optional: false
-- name: tzlocal
-  version: 5.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tzlocal-5.3.1-pyh8f84b5b_0.conda
-  hash:
-    md5: 369f3170d6f727d3102d83274e403b66
-    sha256: 6447388bd870ab0a2b38af5aa64185cd71028a2a702f0935e636a01d81fba7fc
   category: main
   optional: false
 - name: uc-micro-py
@@ -10288,7 +10071,7 @@ package:
   category: main
   optional: false
 - name: urllib3
-  version: 2.6.3
+  version: 2.7.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -10297,10 +10080,10 @@ package:
     h2: '>=4,<5'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 9272daa869e03efe68833e3dc7a02130
-    sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
+    md5: cbb88288f74dbe6ada1c6c7d0a97223e
+    sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
   category: main
   optional: false
 - name: uvicorn

--- a/ci/conda-lock.yml
+++ b/ci/conda-lock.yml
@@ -13,7 +13,7 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: efc6db5542bc57f4b14a183cd9d8881c32c54a774c2e2f76d3faae732bf47c2c
+    linux-64: f26e05f1f8b94b6be20815138071a4813ce05b0f0284adfbe930c00be08dde75
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -383,6 +383,40 @@ package:
   hash:
     md5: 85c4f19f377424eafc4ed7911b291642
     sha256: 792da8131b1b53ff667bd6fc617ea9087b570305ccb9913deb36b8e12b3b5141
+  category: main
+  optional: false
+- name: asf_search
+  version: 12.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    asf_search-base: '>=12.1.0,<12.1.1.0a0'
+    python: '>=3.10'
+    remotezip: '>=0.10.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/asf_search-12.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ed556ecb186256ab63fc51c2f8e36006
+    sha256: 1f2309ef6cda29c5bc5dc92308d1a5c20b532cdea83b246ccae22213b905392b
+  category: main
+  optional: false
+- name: asf_search-base
+  version: 12.1.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    ciso8601: ''
+    dateparser: ''
+    importlib-metadata: ''
+    numpy: ''
+    python: '>=3.10'
+    pytz: ''
+    requests: ''
+    shapely: ''
+    tenacity: 8.2.2
+  url: https://conda.anaconda.org/conda-forge/noarch/asf_search-base-12.1.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: b9d6686080a566d802ffba0205435de4
+    sha256: 77316c4fc41387deeb089549067c5edf228e7814b3e3685975eb5eb77beeb4fe
   category: main
   optional: false
 - name: asttokens
@@ -1450,6 +1484,21 @@ package:
     sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
   category: main
   optional: false
+- name: ciso8601
+  version: 2.3.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    python: ''
+    python_abi: 3.13.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/ciso8601-2.3.3-py313h54dd161_1.conda
+  hash:
+    md5: ec4754d3f7cd32b8db467f6749884545
+    sha256: 277fc59168939623b954b9537eaef2d4f955dd120136f7d8931687152c771791
+  category: main
+  optional: false
 - name: click
   version: 8.1.8
   manager: conda
@@ -2029,6 +2078,22 @@ package:
     sha256: cfecc3dad48250f530ebd16f52061cb37bc9fdbdfec25098bf2de8424996b0bc
   category: main
   optional: false
+- name: dateparser
+  version: 1.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.10'
+    python-dateutil: '>=2.7.0'
+    pytz: '>=2024.2'
+    regex: '>=2024.9.11'
+    tzlocal: '>=0.2'
+  url: https://conda.anaconda.org/conda-forge/noarch/dateparser-1.4.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 4d8650857be15983a33032bf18059787
+    sha256: 9ccdd848db68efc03afbf5fc67e92accc912c0b609a4f4ba54b720f0c27c41a2
+  category: main
+  optional: false
 - name: dav1d
   version: 1.2.1
   manager: conda
@@ -2198,6 +2263,18 @@ package:
   hash:
     md5: 7635e4907164a088d932f7d8965db7ab
     sha256: fb8c1b918b3c28ff9cdf21279aad9a50a659dd3bcbdb95d687044fb35b58b2df
+  category: main
+  optional: false
+- name: docstring_parser
+  version: 0.17.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: ce49d3e5a7d20be2ba57a2c670bdd82e
+    sha256: 3069a555097f084d3b7bc8f9efbb42f9907ecbfa24d310c63df9814a8df491af
   category: main
   optional: false
 - name: donfig
@@ -5481,6 +5558,39 @@ package:
     sha256: 298497351f4a7dc94938a1ad8dc3df545a07efdc5f1b91b9256d04e65959a430
   category: main
   optional: false
+- name: libgdal-hdf4
+  version: 3.12.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    hdf4: '>=4.2.15,<4.2.16.0a0'
+    libaec: '>=1.1.5,<2.0a0'
+    libgcc: '>=14'
+    libgdal-core: 3.12.3
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.3-hf70aa56_3.conda
+  hash:
+    md5: 5429ab06028218ac67e11695b4b66a96
+    sha256: dc0ffd3fdce474ff3f975dadda48f971bff6604b83391b3cd9b4c3e43408335e
+  category: main
+  optional: false
+- name: libgdal-hdf5
+  version: 3.12.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    hdf5: '>=2.1.0,<3.0a0'
+    libgcc: '>=14'
+    libgdal-core: 3.12.3
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.3-ha9bf034_3.conda
+  hash:
+    md5: f019b2a48a736bf0357b0e24176ab941
+    sha256: 168bf24d820814a1bea1f1e308eb1116bea11e218ad5e018014f68e04852bc16
+  category: main
+  optional: false
 - name: libgdal-jp2openjpeg
   version: 3.12.3
   manager: conda
@@ -5495,6 +5605,26 @@ package:
   hash:
     md5: a4b72bb65bb5fe234c82f3e3adc4a50e
     sha256: d02e8a3a9dd288acb5006150783ab93a4d1a6dec4c1b0eb60699456f52efda77
+  category: main
+  optional: false
+- name: libgdal-netcdf
+  version: 3.12.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    hdf4: '>=4.2.15,<4.2.16.0a0'
+    hdf5: '>=2.1.0,<3.0a0'
+    libgcc: '>=14'
+    libgdal-core: 3.12.3
+    libgdal-hdf4: 3.12.3.*
+    libgdal-hdf5: 3.12.3.*
+    libnetcdf: '>=4.10.0,<4.10.1.0a0'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.3-ha903712_3.conda
+  hash:
+    md5: 558c0691cd8ff91fd0baeb4943476a8a
+    sha256: 0be40bdfcd0964e1c092d6524167524925039821be3d3be5cd7b60c3c37f0799
   category: main
   optional: false
 - name: libgfortran
@@ -6697,23 +6827,23 @@ package:
   category: main
   optional: false
 - name: minizip
-  version: 4.0.10
+  version: 4.2.1
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libgcc: '>=13'
+    libgcc: '>=14'
     libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.1,<6.0a0'
-    libstdcxx: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.0,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.6,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.10-h05a5f5f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.1-hb71707f_0.conda
   hash:
-    md5: da01bb40572e689bd1535a5cee6b1d68
-    sha256: 0c3700d15377156937ddc89a856527ad77e7cf3fd73cb0dffc75fce8030ddd16
+    md5: fe7b4ff5792fee512aad843294ea809a
+    sha256: 41558b95a387ce2374260aa034a99c3a88cbb98e1a56510f4fa6839063de867b
   category: main
   optional: false
 - name: mistune
@@ -7401,22 +7531,37 @@ package:
   category: main
   optional: false
 - name: opera-utils
-  version: 0.19.0
+  version: 0.25.6
   manager: conda
   platform: linux-64
   dependencies:
-    click: '>=7.0'
+    affine: ''
+    aiohttp: ''
+    asf_search: '>=6.7'
+    botocore: ''
+    dask: ''
+    fsspec: ''
+    gdal: '>=3.8'
+    h5netcdf: ''
     h5py: '>=1.10'
+    libgdal-netcdf: ''
     numpy: '>=1.20'
+    pandas: ''
     pooch: '>=1.7'
     pyproj: '>=3.3'
-    python: '>=3.9'
+    python: '>=3.11'
+    rasterio: '>=1.3'
+    s3fs: ''
     shapely: '>=1.8'
+    tqdm: ''
     typing_extensions: '>=4.9'
-  url: https://conda.anaconda.org/conda-forge/noarch/opera-utils-0.19.0-pyhd8ed1ab_0.conda
+    tyro: '>=0.9'
+    xarray: '>=2025.01'
+    zarr: '>=3'
+  url: https://conda.anaconda.org/conda-forge/noarch/opera-utils-0.25.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 8625745d1b02bb0f4777b91046042e6d
-    sha256: cc479dc68c7dd965ec8a7b94ef83ce5036eafb4dc15f9041e15adc6ce5169c81
+    md5: 184b48a8ff281cfb71d69d07f94d802e
+    sha256: adbad1d2ebbc379628382a21c8b70ae81f2e6892e7bfc7bd1a9e5743e98fa738
   category: main
   optional: false
 - name: orc
@@ -8878,6 +9023,19 @@ package:
     sha256: 26a0ac1a217e008e0cdfd09888f669d916305a0c00a2def6ed547d0c4346ade4
   category: main
   optional: false
+- name: remotezip
+  version: 0.12.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.9'
+    requests: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/remotezip-0.12.3-pyhd8ed1ab_1.conda
+  hash:
+    md5: ae636b9c45eaf85205950fc94401fd8b
+    sha256: ef52d7c1870a13740df224f370ff6457f1135f319ab7a0a2b13ce5fd34b0eeab
+  category: main
+  optional: false
 - name: requests
   version: 2.32.5
   manager: conda
@@ -9383,6 +9541,18 @@ package:
     sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
   category: main
   optional: false
+- name: shtab
+  version: 1.8.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/shtab-1.8.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3b92b45edc5da4cbd603dd7a059f402a
+    sha256: 02567ec721dd5ff6e8942c1cf1db9bb12df64409ff48fc3571b212c122ef9006
+  category: main
+  optional: false
 - name: simpervisor
   version: 1.0.0
   manager: conda
@@ -9698,15 +9868,15 @@ package:
   category: main
   optional: false
 - name: tenacity
-  version: 9.1.4
+  version: 8.2.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
+    python: '>=3.6'
+  url: https://conda.anaconda.org/conda-forge/noarch/tenacity-8.2.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 043f0599dc8aa023369deacdb5ac24eb
-    sha256: 32e75900d6a094ffe4290a8c9f1fa15744d9da8ff617aba4acaa0f057a065c34
+    md5: 7b39e842b52966a99e229739cd4dc36e
+    sha256: 23abf9c14b59fa9787a56a6abb519ac14a9b19091d6c5d7446886d955493b95e
   category: main
   optional: false
 - name: terminado
@@ -9902,6 +10072,21 @@ package:
     sha256: d8f62a784845800fc6b196b7b996757844238ab30438bc8db2ebc32b1132bb0d
   category: main
   optional: false
+- name: typeguard
+  version: 4.5.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    importlib-metadata: '>=3.6'
+    python: ''
+    typing-extensions: '>=4.10.0'
+    typing_extensions: '>=4.14.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.5.1-pyhcf101f3_1.conda
+  hash:
+    md5: 7b80dd11eca2644aac219fd17e9cb035
+    sha256: 3191f16e1effbb16c30b42bc74c37392d3ddc08a8abbd129932755e4698e6e07
+  category: main
+  optional: false
 - name: typing-extensions
   version: 4.15.0
   manager: conda
@@ -9965,6 +10150,26 @@ package:
     sha256: 2051dee6a67d43a0ff0fd2ff9dacd8ef533e89d0b30feedf87613fc84b00c247
   category: main
   optional: false
+- name: tyro
+  version: 1.0.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    colorama: '>=0.4.0'
+    docstring_parser: '>=0.15'
+    eval_type_backport: '>=0.1.3'
+    python: '>=3.10'
+    pyyaml: '>=6.0'
+    rich: '>=11.1.0'
+    shtab: '>=1.5.6'
+    typeguard: '>=4.0.0'
+    typing-extensions: '>=4.13.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/tyro-1.0.13-pyhd8ed1ab_0.conda
+  hash:
+    md5: 2ee651810ee627d8fc9aeee98490ab60
+    sha256: 43d8a2228bc61aa7285f547fb7fd734aa9dc420edcf6e88828b2f67419e767b8
+  category: main
+  optional: false
 - name: tzdata
   version: 2025c
   manager: conda
@@ -9974,6 +10179,19 @@ package:
   hash:
     md5: ad659d0a2b3e47e38d829aa8cad2d610
     sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
+  category: main
+  optional: false
+- name: tzlocal
+  version: 5.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/tzlocal-5.3.1-pyh8f84b5b_0.conda
+  hash:
+    md5: 369f3170d6f727d3102d83274e403b66
+    sha256: 6447388bd870ab0a2b38af5aa64185cd71028a2a702f0935e636a01d81fba7fc
   category: main
   optional: false
 - name: uc-micro-py
@@ -10839,6 +11057,17 @@ package:
   url: https://files.pythonhosted.org/packages/15/df/6f249cd3c3db684c8f9e67bc5470c4b593f882fbb03b1649f72ae7a26566/jupyter-desktop-server-0.1.3.tar.gz
   hash:
     sha256: 5915a2dbbe250f59b3cc01859297b26b2e1836e03a5db4bfbfd438005649d7e4
+  category: main
+  optional: false
+- name: jupyter-positron-server
+  version: 0.0.4
+  manager: pip
+  platform: linux-64
+  dependencies:
+    jupyter-server-proxy: '>=4.1.2'
+  url: https://files.pythonhosted.org/packages/c6/fc/847bc6a8bd45a90f0a30bbc48b9fd5450d6c95171794d626e4ec83f5c440/jupyter_positron_server-0.0.4-py3-none-any.whl
+  hash:
+    sha256: 59e68315eb7f650d0fa0e152182c609eceb916e3d788b0d68fbf9ebaf7ff40c5
   category: main
   optional: false
 - name: jupyter-sshd-proxy

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -68,7 +68,7 @@ dependencies:
   - icepyx
   - harmony-py
   - sliderule>=3.6.0
-  - earthaccess>=0.17.0
+  - earthaccess>=0.18.0
   - pystac-client
   - itslive
   - s3fs

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -120,5 +120,6 @@ dependencies:
       - jupyterlab-open-url-parameter
       - pigz
       - jupyter-sshd-proxy
+      - jupyter-positron-server
 platforms:
   - linux-64

--- a/ci/install-positron.sh
+++ b/ci/install-positron.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download Positron server to temporary directory
+# Note: this is the url for x64 architecture machines
+curl -L "https://cdn.posit.co/positron/releases/server/x86_64/positron-server-linux-x64-2026.05.0-179.tar.gz" -o /tmp/positron-server.tar.gz
+
+# Create directory
+mkdir -p /opt/positron-server
+
+# Unpack Positron Server into newly created directory
+tar -xzf /tmp/positron-server.tar.gz -C /opt/positron-server --strip-components=1
+
+rm /tmp/positron-server.tar.gz


### PR DESCRIPTION
This installs [positron server](https://posit-dev.github.io/jupyter-positron-server/) on the image, for which we have an education license. The license file has been [mounted on the hub](https://github.com/2i2c-org/infrastructure/pull/8258) as a kubernetes secret.

I've also bumped earthaccess to v0.18 which has a critical bug fix for streaming in-region (https://github.com/earthaccess-dev/earthaccess/issues/1331).

Tested on the hub with custom image using: `openscapes/python:3c5ecb1`.